### PR TITLE
Fix wildcard `import` statement

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -18,7 +18,7 @@ _.isFunction(() => {});`;
       const result = runPlugin(src);
 
       expect(result).toMatchInlineSnapshot(
-        `"import { * as _ } from 'es-toolkit/compat';
+        `"import * as _ from 'es-toolkit/compat';
 _.isEqual({}, {});
 _.isFunction(() => {});"`,
       );
@@ -43,7 +43,7 @@ lodash.isEqual({}, {});`;
 
       const result = runPlugin(src);
 
-      expect(result).toMatchInlineSnapshot(`"import { * as lodash } from 'es-toolkit/compat';
+      expect(result).toMatchInlineSnapshot(`"import * as lodash from 'es-toolkit/compat';
 totallynotlodash.every([], () => true);
 lodash.isEqual({}, {});"`);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export default function viteEsToolkitPlugin(): {
          * ```
          * with:
          * ```
-         * import { * as lodash } from 'es-toolkit/compat';
+         * import * as lodash from 'es-toolkit/compat';
          * ```
          * provided that no unsupported functions are used.
          */
@@ -112,7 +112,7 @@ export default function viteEsToolkitPlugin(): {
               return match;
             }
 
-            return `import { * as ${defaultImportName} } from 'es-toolkit/compat'`;
+            return `import * as ${defaultImportName} from 'es-toolkit/compat'`;
           },
         );
 


### PR DESCRIPTION
```tsx
import { * as lodash } from 'es-toolkit/compat';
```

In order to be valid code, we have to remove the brackets.