### PR TITLE
Add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
     "type": "git",
     "url": "git+https://github.com/wojtekmaj/vite-plugin-es-toolkit.git"
   },
+  "homepage": "https://github.com/wojtekmaj/vite-plugin-es-toolkit#readme",
+  "bugs": {
+    "url": "https://github.com/wojtekmaj/vite-plugin-es-toolkit/issues"
+  },
   "funding": "https://github.com/wojtekmaj/vite-plugin-es-toolkit?sponsor=1",
   "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to this repository README
- add npm `bugs.url` metadata pointing to this repository issues page

## Validation
- `npm view vite-plugin-es-toolkit@1.1.0 name version homepage repository bugs --json`
- metadata smoke check for `homepage` and `bugs.url`
- `npm pack --dry-run --ignore-scripts`
- `npx --yes @yarnpkg/cli-dist@4.14.1 install --immutable --mode=skip-build`
- `npx --yes @yarnpkg/cli-dist@4.14.1 build`
- `npx --yes @yarnpkg/cli-dist@4.14.1 test`
- `git diff --check`